### PR TITLE
Restrict sandbox guard write access to specific ~/.claude/ subdirs

### DIFF
--- a/lumon/__init__.py
+++ b/lumon/__init__.py
@@ -1,4 +1,4 @@
 from lumon.interpreter import interpret
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __all__ = ["interpret"]

--- a/lumon/_deploy/sandbox-guard.py
+++ b/lumon/_deploy/sandbox-guard.py
@@ -157,6 +157,16 @@ def _is_within_home_subdir(path: str, subdir: str) -> bool:
     return resolved == allowed or resolved.startswith(allowed + os.sep)
 
 
+# ~/.claude/ subdirectories the agent may read and write (memory, plans, tasks, session data).
+# Everything else in ~/.claude/ (settings, hooks, mcp-servers, etc.) is off-limits for writes.
+_CLAUDE_HOME_RW_SUBDIRS = ("projects", "plans", "tasks", "todos")
+
+
+def _is_in_claude_home_rw(path: str) -> bool:
+    """Check if path is within an allowed read/write subdirectory of ~/.claude/."""
+    return any(_is_within_home_subdir(path, os.path.join(".claude", d)) for d in _CLAUDE_HOME_RW_SUBDIRS)
+
+
 def _block(reason: str) -> None:
     logging.warning("BLOCKED: %s", reason)
     print(f"BLOCKED: {reason}", file=sys.stderr)
@@ -179,24 +189,24 @@ def main() -> None:
 
     elif tool == "Write":
         file_path = tool_input.get("file_path", "")
-        if _is_within(file_path, "sandbox") or _is_within(file_path, ".claude"):
+        if _is_within(file_path, "sandbox") or _is_in_claude_home_rw(file_path):
             logging.info("ALLOWED Write: %s", file_path)
             return
-        _block(f"Write only allowed in sandbox/ and .claude/ directories.\n  Attempted: {file_path}")
+        _block(f"Write only allowed in sandbox/ and ~/.claude/{{projects,plans,tasks,todos}}/.\n  Attempted: {file_path}")
 
     elif tool == "Edit":
         file_path = tool_input.get("file_path", "")
-        if _is_within(file_path, "sandbox") or _is_within(file_path, ".claude"):
+        if _is_within(file_path, "sandbox") or _is_in_claude_home_rw(file_path):
             logging.info("ALLOWED Edit: %s", file_path)
             return
-        _block(f"Edit only allowed in sandbox/ and .claude/ directories.\n  Attempted: {file_path}")
+        _block(f"Edit only allowed in sandbox/ and ~/.claude/{{projects,plans,tasks,todos}}/.\n  Attempted: {file_path}")
 
     elif tool == "Read":
         file_path = tool_input.get("file_path", "")
-        if _is_within(file_path, ".") or _is_within_home_subdir(file_path, ".claude"):
+        if _is_within(file_path, ".") or _is_in_claude_home_rw(file_path):
             logging.info("ALLOWED Read: %s", file_path)
             return
-        _block(f"Read only allowed in current directory and ~/.claude/.\n  Attempted: {file_path}")
+        _block(f"Read only allowed in current directory and ~/.claude/{{projects,plans,tasks,todos}}/.\n  Attempted: {file_path}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lumon"
-version = "0.7.0"
+version = "0.7.1"
 description = "A minimal, safe, pseudocode-like interpreted language for AI agents"
 requires-python = ">=3.11"
 dependencies = ["lark>=1.3"]

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -454,12 +454,27 @@ assert_eq "deploy: hook allows Edit in sandbox" \
     "" \
     "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": "sandbox/foo.lumon"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
 
-# Edit hook: allowed inside .claude/ (memory)
-assert_eq "deploy: hook allows Edit in .claude" \
+# Edit hook: allowed inside ~/.claude/projects/ (memory, sessions)
+assert_eq "deploy: hook allows Edit in ~/.claude/projects" \
     "" \
-    "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": ".claude/memory/MEMORY.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
+    "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": "'"$HOME"'/.claude/projects/test/memory/MEMORY.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
 
-# Edit hook: blocked outside sandbox and .claude
+# Edit hook: allowed inside ~/.claude/plans/
+assert_eq "deploy: hook allows Edit in ~/.claude/plans" \
+    "" \
+    "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": "'"$HOME"'/.claude/plans/plan.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
+
+# Edit hook: blocked inside project .claude/ (agent config)
+assert_contains "deploy: hook blocks Edit in .claude config" \
+    "BLOCKED" \
+    "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": ".claude/settings.json"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
+
+# Edit hook: blocked inside ~/.claude/ outside allowed subdirs
+assert_contains "deploy: hook blocks Edit in ~/.claude root" \
+    "BLOCKED" \
+    "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": "'"$HOME"'/.claude/CLAUDE.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
+
+# Edit hook: blocked outside sandbox
 assert_contains "deploy: hook blocks Edit outside sandbox" \
     "BLOCKED" \
     "$(echo '{"tool_name": "Edit", "tool_input": {"file_path": "CLAUDE.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
@@ -474,12 +489,27 @@ assert_eq "deploy: hook allows Write in sandbox" \
     "" \
     "$(echo '{"tool_name": "Write", "tool_input": {"file_path": "sandbox/tmp/test.lumon"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
 
-# Write hook: allowed inside .claude/ (memory)
-assert_eq "deploy: hook allows Write in .claude" \
+# Write hook: allowed inside ~/.claude/projects/ (memory, sessions)
+assert_eq "deploy: hook allows Write in ~/.claude/projects" \
     "" \
-    "$(echo '{"tool_name": "Write", "tool_input": {"file_path": ".claude/memory/patterns.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
+    "$(echo '{"tool_name": "Write", "tool_input": {"file_path": "'"$HOME"'/.claude/projects/test/memory/patterns.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
 
-# Write hook: blocked outside sandbox and .claude
+# Write hook: allowed inside ~/.claude/todos/
+assert_eq "deploy: hook allows Write in ~/.claude/todos" \
+    "" \
+    "$(echo '{"tool_name": "Write", "tool_input": {"file_path": "'"$HOME"'/.claude/todos/todo.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
+
+# Write hook: blocked inside project .claude/ (agent config)
+assert_contains "deploy: hook blocks Write in .claude config" \
+    "BLOCKED" \
+    "$(echo '{"tool_name": "Write", "tool_input": {"file_path": ".claude/CLAUDE.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
+
+# Write hook: blocked inside ~/.claude/ outside allowed subdirs
+assert_contains "deploy: hook blocks Write in ~/.claude root" \
+    "BLOCKED" \
+    "$(echo '{"tool_name": "Write", "tool_input": {"file_path": "'"$HOME"'/.claude/settings.json"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
+
+# Write hook: blocked outside sandbox
 assert_contains "deploy: hook blocks Write outside sandbox" \
     "BLOCKED" \
     "$(echo '{"tool_name": "Write", "tool_input": {"file_path": "secret.txt"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
@@ -493,12 +523,22 @@ assert_eq "deploy: hook allows Read in sandbox subdir" \
     "" \
     "$(echo '{"tool_name": "Read", "tool_input": {"file_path": "sandbox/foo.lumon"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
 
-# Read hook: allowed for ~/.claude/ tool result files
-assert_eq "deploy: hook allows Read in ~/.claude" \
+# Read hook: allowed for ~/.claude/projects/ (tool results, subagents, memory)
+assert_eq "deploy: hook allows Read in ~/.claude/projects" \
     "" \
     "$(echo '{"tool_name": "Read", "tool_input": {"file_path": "'"$HOME"'/.claude/projects/test/tool-results/abc123.txt"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
 
-# Read hook: blocked outside current directory and ~/.claude
+# Read hook: allowed for ~/.claude/tasks/
+assert_eq "deploy: hook allows Read in ~/.claude/tasks" \
+    "" \
+    "$(echo '{"tool_name": "Read", "tool_input": {"file_path": "'"$HOME"'/.claude/tasks/task.md"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1)"
+
+# Read hook: blocked for ~/.claude/ outside allowed subdirs
+assert_contains "deploy: hook blocks Read in ~/.claude root" \
+    "BLOCKED" \
+    "$(echo '{"tool_name": "Read", "tool_input": {"file_path": "'"$HOME"'/.claude/settings.json"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"
+
+# Read hook: blocked outside current directory
 assert_contains "deploy: hook blocks Read outside current dir" \
     "BLOCKED" \
     "$(echo '{"tool_name": "Read", "tool_input": {"file_path": "../outside/secret.txt"}}' | python3 "$DEPLOY_ROOT/.claude/hooks/sandbox-guard.py" 2>&1 || true)"


### PR DESCRIPTION
## Summary
- Removed blanket Write/Edit access to the project `.claude/` directory from the sandbox guard — agents could previously modify their own `CLAUDE.md`, `settings.json`, and hooks (prompt injection vector)
- Scoped `~/.claude/` access to only the subdirectories agents legitimately need: `projects/` (memory, sessions, subagent logs), `plans/`, `tasks/`, `todos/`
- Tightened Read access from all of `~/.claude/` to the same allowlisted subdirs

## Test plan
- [x] Existing CLI bash tests updated and passing (131/131, 1 pre-existing unrelated failure in schedule logs)
- [x] New tests: Edit/Write allowed in `~/.claude/projects/`, `~/.claude/plans/`, `~/.claude/todos/`
- [x] New tests: Edit/Write blocked for project `.claude/settings.json`, `~/.claude/CLAUDE.md`, `~/.claude/settings.json`
- [x] Read blocked for `~/.claude/` root files, allowed for `~/.claude/projects/` and `~/.claude/tasks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)